### PR TITLE
Fix appdata.xml which was failing to validate

### DIFF
--- a/com.endlessnetwork.dragonsapprentice.appdata.xml
+++ b/com.endlessnetwork.dragonsapprentice.appdata.xml
@@ -21,15 +21,15 @@
   <screenshots>
     <screenshot type="default">
       <image type="source">https://github.com/endless-network/DragonsApprentice_Binary/raw/master/DA5.jpg</image>
-      <caption>Experience Ovun’s Historia.</caption>
+      <caption>Experience Ovun’s Historia</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://github.com/endless-network/DragonsApprentice_Binary/raw/master/DA4.jpg</image>
-      <caption>Epic adventure across dungeons.</caption>
+      <caption>Epic adventure across dungeons</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://github.com/endless-network/DragonsApprentice_Binary/raw/master/DA3.png</image>
-      <caption>Epic adventure.</caption>
+      <caption>Epic adventure</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://github.com/endless-network/DragonsApprentice_Binary/raw/master/DA2.png</image>


### PR DESCRIPTION
The following validator was failing...

    flatpak run org.freedesktop.appstream-glib validate com.endlessnetwork.dragonsapprentice.appdata.xml

With this output:

    com.endlessnetwork.dragonsapprentice.appdata.xml: FAILED:
    • style-invalid         : <caption> cannot end in '.' [Experience Ovun’s Historia.]
    • style-invalid         : <caption> cannot end in '.' [Epic adventure across dungeons.]
    • style-invalid         : <caption> cannot end in '.' [Epic adventure.]
